### PR TITLE
Fix phone link, lazy load images, add doc and tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,30 @@
+# サンコーネーム サイト
+
+このリポジトリは就労継続支援B型事業所「株式会社サンコーネーム」のサンプルサイトです。
+
+## 主な機能
+- ヘッダーの表示・非表示制御
+- スムーズスクロール
+- 画像の遅延読み込み
+
+## 画像の遅延読み込みについて
+`img` タグに `data-src` 属性を指定し、`src` には 1x1 ピクセルのプレースホルダー画像を設定しています。ページ読み込み後、`IntersectionObserver` により `data-src` の値が `src` に移され、画像がロードされます。
+
+```html
+<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/example.jpg" alt="例">
+```
+
+```javascript
+if (image.dataset.src) {
+    image.src = image.dataset.src;
+    image.removeAttribute('data-src');
+}
+```
+
+## セットアップ
+テスト実行には Node.js が必要です。依存関係をインストールして Jest を実行します。
+
+```bash
+npm install
+npm test
+```

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('basic interactions', () => {
+  let document;
+  let window;
+  beforeAll(() => {
+    const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+    window = dom.window;
+    document = dom.window.document;
+  });
+
+  test('notification close button hides banner', () => {
+    const closeBtn = document.querySelector('.h-notification__remove');
+    const notification = document.querySelector('.h-notification');
+    expect(notification.style.display).not.toBe('none');
+    closeBtn.dispatchEvent(new window.Event('click'));
+    expect(notification.style.display).toBe('none');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <div class="my-head__overlay">
                 <div class="my-head__content">
                     <h1 class="my-head__logo">
-                        <img src="img/friendly staff members.jpg" alt="株式会社サンコーネーム" class="my-head__logo__img my-head__logo__img--loaded">
+                        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/friendly staff members.jpg" alt="株式会社サンコーネーム" class="my-head__logo__img my-head__logo__img--loaded">
                     </h1>
                     <h2 class="my-head__title">就労継続支援B型事業所</h2>
                     <p class="my-head__subtitle">障がいのある方の就労と自立をサポート</p>
@@ -120,7 +120,7 @@
                             </ul>
                         </div>
                         <div class="about-grid__image">
-                            <img src="img/A caring female staff member smiling and guiding01.jpg" alt="スタッフがサポートしている様子">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/A caring female staff member smiling and guiding01.jpg" alt="スタッフがサポートしている様子">
                         </div>
                     </div>
                 </div>
@@ -135,7 +135,7 @@
                     <div class="service-cards">
                         <div class="service-card">
                             <div class="service-card__image">
-                                <img src="img/folding pamphlets and inserting them into envelopes.jpg" alt="封入作業">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/folding pamphlets and inserting them into envelopes.jpg" alt="封入作業">
                             </div>
                             <div class="service-card__content">
                                 <h3 class="service-card__title">軽作業</h3>
@@ -147,7 +147,7 @@
                         </div>
                         <div class="service-card">
                             <div class="service-card__image">
-                                <img src="img/developmental disability working on a laptop.jpg" alt="パソコン作業">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/developmental disability working on a laptop.jpg" alt="パソコン作業">
                             </div>
                             <div class="service-card__content">
                                 <h3 class="service-card__title">パソコン作業</h3>
@@ -159,7 +159,7 @@
                         </div>
                         <div class="service-card">
                             <div class="service-card__image">
-                                <img src="img/A person harvesting vegetables.jpg" alt="農作業">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/A person harvesting vegetables.jpg" alt="農作業">
                             </div>
                             <div class="service-card__content">
                                 <h3 class="service-card__title">農作業</h3>
@@ -171,7 +171,7 @@
                         </div>
                         <div class="service-card">
                             <div class="service-card__image">
-                                <img src="img/disability participating in light outdoor maintenance tasks.jpg" alt="清掃作業">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/disability participating in light outdoor maintenance tasks.jpg" alt="清掃作業">
                             </div>
                             <div class="service-card__content">
                                 <h3 class="service-card__title">清掃作業</h3>
@@ -193,19 +193,19 @@
                 <div class="section__content">
                     <div class="facility-gallery">
                         <div class="facility-gallery__item">
-                            <img src="img/spacious room inside a supportive workplace.jpg" alt="作業スペース">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/spacious room inside a supportive workplace.jpg" alt="作業スペース">
                             <p class="facility-gallery__caption">広々とした作業スペース</p>
                         </div>
                         <div class="facility-gallery__item">
-                            <img src="img/An open and spacious room inside a supportive workplace02.jpg" alt="ミーティングスペース">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/An open and spacious room inside a supportive workplace02.jpg" alt="ミーティングスペース">
                             <p class="facility-gallery__caption">ミーティングスペース</p>
                         </div>
                         <div class="facility-gallery__item">
-                            <img src="img/A cozy break area in a disability support facility01.jpg" alt="休憩スペース">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/A cozy break area in a disability support facility01.jpg" alt="休憩スペース">
                             <p class="facility-gallery__caption">リラックスできる休憩スペース</p>
                         </div>
                         <div class="facility-gallery__item">
-                            <img src="img/A caring female staff member smiling and guiding02.jpg" alt="スタッフサポート">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/A caring female staff member smiling and guiding02.jpg" alt="スタッフサポート">
                             <p class="facility-gallery__caption">親切なスタッフがサポート</p>
                         </div>
                     </div>
@@ -262,7 +262,7 @@
                                 <h4 class="contact-grid__method-title">電話でのお問い合わせ</h4>
                                 <p class="contact-grid__phone">06-XXXX-XXXX</p>
                                 <p class="contact-grid__hours">受付時間：平日 9:00〜18:00</p>
-                                <a href="tel:06XXXXXXXX" class="h-btn h-btn--primary h-btn--stack">
+                                <a href="tel:06-XXXX-XXXX" class="h-btn h-btn--primary h-btn--stack">
                                     <div class="h-btn__content">
                                         <span class="h-btn__stack-main">お電話する</span>
                                         <span class="h-btn__stack-sub">06-XXXX-XXXX</span>
@@ -281,7 +281,7 @@
                             </div>
                         </div>
                         <div class="contact-grid__image">
-                            <img src="img/A caring female staff member smiling and guiding03.jpg" alt="スタッフがお迎えする様子">
+                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="img/A caring female staff member smiling and guiding03.jpg" alt="スタッフがお迎えする様子">
                         </div>
                     </div>
                 </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "0506_beb5clone",
+  "version": "1.0.0",
+  "description": "このリポジトリは就労継続支援B型事業所\u300c株式会社サンコーネーム\u300dのサンプルサイトです。",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^23.2.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -62,19 +62,22 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
-    const lazyImages = document.querySelectorAll('img');
-    
+    const lazyImages = document.querySelectorAll('img[data-src]');
+
     if ('IntersectionObserver' in window) {
         const imageObserver = new IntersectionObserver(function(entries, observer) {
             entries.forEach(function(entry) {
                 if (entry.isIntersecting) {
                     const image = entry.target;
-                    image.src = image.src; // 実際のプロジェクトではdata-srcなどの属性を使用
+                    if (image.dataset.src) {
+                        image.src = image.dataset.src; // data-src属性から画像を読み込む
+                        image.removeAttribute('data-src');
+                    }
                     imageObserver.unobserve(image);
                 }
             });
         });
-        
+
         lazyImages.forEach(function(image) {
             imageObserver.observe(image);
         });


### PR DESCRIPTION
## Summary
- update phone link to match displayed number
- implement data-src lazy loading in `script.js`
- update all `<img>` tags to use `data-src` with a placeholder image
- document lazy loading in README
- add basic Jest test and package.json

## Testing
- `npm test` *(fails: jest not found)*